### PR TITLE
Adding to requirements_dev.txt to fix documentation generation

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ tox==2.9.1
 coverage==4.5.1
 Sphinx==1.7.1
 twine==1.10.0
-redis=2.10.5
+redis==2.10.5
 
 pytest==3.4.2
 pytest-runner==2.11.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ coverage==4.5.1
 Sphinx==1.7.1
 twine==1.10.0
 redis==2.10.5
+blinker==1.4
 
 pytest==3.4.2
 pytest-runner==2.11.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,7 @@ tox==2.9.1
 coverage==4.5.1
 Sphinx==1.7.1
 twine==1.10.0
+redis=2.10.5
 
 pytest==3.4.2
 pytest-runner==2.11.1


### PR DESCRIPTION
Documentation generation was broken on readthedocs.io due to requirements missing from requirements_dev.txt.  This PR adds those.  Fixed documentation can be seen [here](https://region-cache-stumpc.readthedocs.io/en/latest/) for proof.